### PR TITLE
Correct a typo in the package.json (missing comma)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "tslint-config-airbnb": "^5.11.0",
     "tslint-eslint-rules": "^5.4.0",
     "tslint-language-service": "^0.9.9",
-    "typescript": "^3.1.6"
+    "typescript": "^3.1.6",
     "readium-cfi-js": "^1.0.0-alpha.1"
   }
 }


### PR DESCRIPTION
Noticed this typo while experimenting with building the webpub-viewer.